### PR TITLE
Make white space between : and keyword set optional

### DIFF
--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -92,7 +92,7 @@ fun! <SID>CheckVersion(op, ver) abort
 endfun
 
 fun! <SID>DoModeline(line) abort
-    let l:matches = matchlist(a:line, '\%(\S\@<!\%(vi\|vim\([<>=]\?\)\([0-9]\+\)\?\)\|\sex\):\s*set\?\s\+\([^:]\+\):\S\@!')
+    let l:matches = matchlist(a:line, '\%(\S\@<!\%(vi\|vim\([<>=]\?\)\([0-9]\+\)\?\)\|\sex\):\s*\(set\s\+\)\?\([^:]\+\):\S\@!')
     if len(l:matches) > 0
         let l:operator = ">"
         if len(l:matches[1]) > 0


### PR DESCRIPTION
According to the vim documentation (:help modeline), the white space
between ':' and the keyword 'set' is optional:

```
[text]{white}{vi:|vim:|ex:}[white]{options}
```

[text]      any text or empty
{white}     at least one blank character (<Space> or <Tab>)
{vi:|vim:|ex:}  the string "vi:", "vim:" or "ex:"
[white]     optional white space
{options}   a list of option settings, separated with white space or ':',
        where each part between ':' is the argument for a ":set"
        command (can be empty)

Thus, the regular expression has been changed to match zero or more
white spaces, rather than one or more.
