### PR TITLE
Do not require a white space between {vi:|vim:|ex:}: and {options}

### DIFF
--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -92,7 +92,7 @@ fun! <SID>CheckVersion(op, ver) abort
 endfun
 
 fun! <SID>DoModeline(line) abort
-    let l:matches = matchlist(a:line, '\%(\S\@<!\%(vi\|vim\([<>=]\?\)\([0-9]\+\)\?\)\|\sex\):\s\+set\?\s\+\([^:]\+\):\S\@!')
+    let l:matches = matchlist(a:line, '\%(\S\@<!\%(vi\|vim\([<>=]\?\)\([0-9]\+\)\?\)\|\sex\):\s*\(set\s\+\)\?\([^:]\+\):\S\@!')
     if len(l:matches) > 0
         let l:operator = ">"
         if len(l:matches[1]) > 0


### PR DESCRIPTION
The Vim documentation (:help modeline) says there are two forms of
modelines:
    [text]{white}{vi:|vim:|ex:}[white]{options}

```
[text]{white}{vi:|vim:|ex:}[white]se[t] {options}:[text]
```

In both cases the white space after {vi:|vim:|ex:}: is optional but the
regular expression used to handle the latter form did require at least
one white space, ignoring otherwise conforming modelines.

To address this, the regular expression has been changed to match
against zero or more white spaces after {vi:|vim:|ex:}: whilst requiring
at least one after the string 'set', if present.

Note that the documentation is not clear if more than one white space is
allowed, this assumes it is.
