### PR TITLE
Match modelines which use +=/-=/^=

### DIFF
--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -55,7 +55,7 @@ fun! <SID>IsInList(list, i) abort
 endfun
 
 fun! <SID>DoOne(item) abort
-    let l:matches = matchlist(a:item, '^\([a-z]\+\)\%(=[a-zA-Z0-9_\-.]\+\)\?$')
+    let l:matches = matchlist(a:item, '^\([a-z]\+\)\%([-+^]\?=[a-zA-Z0-9_\-.]\+\)\?$')
     if len(l:matches) > 0
         if <SID>IsInList(g:secure_modelines_allowed_items, l:matches[1])
             exec "setlocal " . a:item


### PR DESCRIPTION
I've been using a modeline to modify isk for a specific file recently and noticed a couple things weren't being handled properly, this being the easy one to fix.

Signed-off-by: James McCoy vega.james@gmail.com
