### PR TITLE
Disable plugin and add indent options

### DIFF
--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -22,6 +22,9 @@ if (! exists("g:secure_modelines_allowed_items"))
                 \ "foldmethod",  "fdm",
                 \ "readonly",    "ro",   "noreadonly", "noro",
                 \ "rightleft",   "rl",   "norightleft", "norl",
+                \ "cindent",     "cin",  "nocindent", "nocin",
+                \ "smartindent", "si",   "nosmartindent", "nosi",
+                \ "autoindent",  "ai",   "noautoindent", "noai",
                 \ "spell",
                 \ "spelllang"
                 \ ]


### PR DESCRIPTION
The g:loaded_securemodelines patch has been sitting in Debian for a while, so users can disable the plugin if the sysadmin enables it.

The other adds the basic, boolean indent options as suggested in http://bugs.debian.org/642057
