### PR TITLE
Added ',' to the allowed characters in settings

### DIFF
--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -59,7 +59,7 @@ fun! <SID>IsInList(list, i) abort
 endfun
 
 fun! <SID>DoOne(item) abort
-    let l:matches = matchlist(a:item, '^\([a-z]\+\)\%([-+^]\?=[a-zA-Z0-9_\-.]\+\)\?$')
+    let l:matches = matchlist(a:item, '^\([a-z]\+\)\%([-+^]\?=[a-zA-Z0-9_\-,.]\+\)\?$')
     if len(l:matches) > 0
         if <SID>IsInList(g:secure_modelines_allowed_items, l:matches[1])
             exec "setlocal " . a:item


### PR DESCRIPTION
Added the comma character to the allowed characters for a setting so
that it is possible to set more than one value at once. Especially
useful if configuring the spell check language for more than one
language, eg. set spelllang=en,de.
