### PR TITLE
allow &nospell along with &spell

### DIFF
--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -25,7 +25,7 @@ if (! exists("g:secure_modelines_allowed_items"))
                 \ "cindent",     "cin",  "nocindent", "nocin",
                 \ "smartindent", "si",   "nosmartindent", "nosi",
                 \ "autoindent",  "ai",   "noautoindent", "noai",
-                \ "spell",
+                \ "spell", "nospell",
                 \ "spelllang"
                 \ ]
 endif


### PR DESCRIPTION
@ciaranm This is useful when disabling the spell check in a file  whose file has `set spell` by default, such as `text`.