### PR TITLE
Allow foldmarker=[[[,]]] and formatoptions;  add help doc/securemodelines.txt, add README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/README.md
+++ b/README.md
@@ -3,25 +3,15 @@ A secure alternative to Vim modelines
 
 Vim's internal modeline support allows all sorts of annoying and potentially insecure options to be set. This script implements a much more heavily restricted modeline parser that permits only user-specified options to be set. 
 
-The g:secure_modelines_allowed_items array contains allowable options. By default it is set as follows: 
-```vim
-    let g:secure_modelines_allowed_items = [ 
-                \ "textwidth",   "tw", 
-                \ "softtabstop", "sts", 
-                \ "tabstop",     "ts", 
-                \ "shiftwidth",  "sw", 
-                \ "expandtab",   "et",   "noexpandtab", "noet", 
-                \ "filetype",    "ft", 
-                \ "foldmethod",  "fdm", 
-                \ "readonly",    "ro",   "noreadonly", "noro", 
-                \ "rightleft",   "rl",   "norightleft", "norl" 
-                \ ] 
-```
-The `g:secure_modelines_verbose` option, if set to something true, will make the script warn when a modeline attempts to set any other option. 
+The `g:secure_modelines_allowed_items` array contains allowed options.  See `:help securemodelines_options` for default values.
 
-The `g:secure_modelines_modelines` option overrides the number of lines to check. By default it is 5. 
+The `g:secure_modelines_verbose` variable, if set to something true, will make the script warn when a modeline attempts to set any other option.
 
-If `g:secure_modelines_leave_modeline` is defined, the script will not clobber &modeline. Otherwise &modeline will be unset. 
+The `g:secure_modelines_modelines` variable overrides the number of lines to check. By default it is 5.
+
+If `g:secure_modelines_leave_modeline` is defined, the script will not clobber &modeline. Otherwise &modeline will be unset.
+
+Keeping things up to date on vim.org is a nuisance. For the latest version, visit: http://github.com/ciaranm/securemodelines
 
 Install into your plugin directory of choice.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # securemodelines
 A secure alternative to Vim modelines
 
-vim.org: http://www.vim.org/scripts/script.php?script_id=1876
-
-script type: utility
- 
 Vim's internal modeline support allows all sorts of annoying and potentially insecure options to be set. This script implements a much more heavily restricted modeline parser that permits only user-specified options to be set. 
 
 The g:secure_modelines_allowed_items array contains allowable options. By default it is set as follows: 
@@ -27,8 +23,6 @@ The `g:secure_modelines_modelines` option overrides the number of lines to check
 
 If `g:secure_modelines_leave_modeline` is defined, the script will not clobber &modeline. Otherwise &modeline will be unset. 
 
-Keeping things up to date on vim.org is a nuisance. For the latest version, visit: 
-
-    http://github.com/ciaranm/securemodelines
- 
 Install into your plugin directory of choice.
+
+vim.org: http://www.vim.org/scripts/script.php?script_id=1876

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# securemodelines
+A secure alternative to Vim modelines
+
+vim.org: http://www.vim.org/scripts/script.php?script_id=1876
+
+script type: utility
+ 
+Vim's internal modeline support allows all sorts of annoying and potentially insecure options to be set. This script implements a much more heavily restricted modeline parser that permits only user-specified options to be set. 
+
+The g:secure_modelines_allowed_items array contains allowable options. By default it is set as follows: 
+```vim
+    let g:secure_modelines_allowed_items = [ 
+                \ "textwidth",   "tw", 
+                \ "softtabstop", "sts", 
+                \ "tabstop",     "ts", 
+                \ "shiftwidth",  "sw", 
+                \ "expandtab",   "et",   "noexpandtab", "noet", 
+                \ "filetype",    "ft", 
+                \ "foldmethod",  "fdm", 
+                \ "readonly",    "ro",   "noreadonly", "noro", 
+                \ "rightleft",   "rl",   "norightleft", "norl" 
+                \ ] 
+```
+The `g:secure_modelines_verbose` option, if set to something true, will make the script warn when a modeline attempts to set any other option. 
+
+The `g:secure_modelines_modelines` option overrides the number of lines to check. By default it is 5. 
+
+If `g:secure_modelines_leave_modeline` is defined, the script will not clobber &modeline. Otherwise &modeline will be unset. 
+
+Keeping things up to date on vim.org is a nuisance. For the latest version, visit: 
+
+    http://github.com/ciaranm/securemodelines
+ 
+Install into your plugin directory of choice.

--- a/doc/securemodelines.txt
+++ b/doc/securemodelines.txt
@@ -1,0 +1,55 @@
+*securemodelines.txt* A secure alternative to Vim modelines
+
+vim.org: http://www.vim.org/scripts/script.php?script_id=1876
+
+For the latest version, visit: http://github.com/ciaranm/securemodelines
+
+Author: Ciaran McCreesh
+ 
+==============================================================================
+0. Contents                                            *securemodelines-toc*
+
+        1.  Functionality...........................: |securemodelines-plugin|
+        2.  Options.................................: |securemodelines-options|
+
+==============================================================================
+                                                       *securemodelines-plugin*
+
+1.  Functionality
+
+Vim's internal modeline support allows all sorts of annoying and
+potentially insecure options to be set. This script implements a much
+more heavily restricted modeline parser that permits only user-specified
+options to be set.
+
+                                                   *g:securemodelines-options*
+2.  Options
+
+The g:secure_modelines_allowed_items array contains allowable options.
+By default it is set as follows:
+
+    let g:secure_modelines_allowed_items = [ 
+                \ "textwidth",   "tw", 
+                \ "softtabstop", "sts", 
+                \ "tabstop",     "ts", 
+                \ "shiftwidth",  "sw", 
+                \ "expandtab",   "et",   "noexpandtab", "noet", 
+                \ "filetype",    "ft", 
+                \ "foldmethod",  "fdm", 
+                \ "readonly",    "ro",   "noreadonly", "noro", 
+                \ "rightleft",   "rl",   "norightleft", "norl" 
+                \ ] 
+
+The g:secure_modelines_verbose option, if set to something true, will
+make the script warn when a modeline attempts to set any other option.
+
+The g:secure_modelines_modelines option overrides the number of lines to
+check. By default it is 5.
+
+If g:secure_modelines_leave_modeline is defined, the script will not
+clobber &modeline. Otherwise &modeline will be unset.
+
+Install into your plugin directory of choice.
+
+==============================================================================
+vim:tw=78:ts=8:ft=help

--- a/doc/securemodelines.txt
+++ b/doc/securemodelines.txt
@@ -9,11 +9,12 @@ Author: Ciaran McCreesh
 ==============================================================================
 0. Contents                                            *securemodelines-toc*
 
-        1.  Functionality...........................: |securemodelines-plugin|
-        2.  Options.................................: |securemodelines-options|
+        1.  Functionality..........................: |securemodelines-plugin|
+        2.  Plugin settings........................: |securemodelines-settings|
+        2.1 Allowed modeline options...............: |securemodelines_options|
 
 ==============================================================================
-                                                       *securemodelines-plugin*
+                                                      *securemodelines-plugin*
 
 1.  Functionality
 
@@ -22,29 +23,35 @@ potentially insecure options to be set. This script implements a much
 more heavily restricted modeline parser that permits only user-specified
 options to be set.
 
-                                                   *g:securemodelines-options*
+                                                    *securemodelines-settings*
 2.  Options
 
-The g:secure_modelines_allowed_items array contains allowable options.
+The g:secure_modelines_allowed_items array contains allowed options.
 By default it is set as follows:
 
-    let g:secure_modelines_allowed_items = [ 
-                \ "textwidth",   "tw", 
-                \ "softtabstop", "sts", 
-                \ "tabstop",     "ts", 
-                \ "shiftwidth",  "sw", 
-                \ "expandtab",   "et",   "noexpandtab", "noet", 
-                \ "filetype",    "ft", 
-                \ "foldmethod",  "fdm", 
-                \ "readonly",    "ro",   "noreadonly", "noro", 
-                \ "rightleft",   "rl",   "norightleft", "norl" 
-                \ ] 
+                                                     *securemodelines_options*
+    let g:secure_modelines_allowed_items = [
+                \ "textwidth",   "tw",
+                \ "softtabstop", "sts",
+                \ "tabstop",     "ts",
+                \ "shiftwidth",  "sw",
+                \ "expandtab",   "et",   "noexpandtab", "noet",
+                \ "filetype",    "ft",
+                \ "foldmethod",  "fdm",
+                \ "readonly",    "ro",   "noreadonly", "noro",
+                \ "rightleft",   "rl",   "norightleft", "norl",
+                \ "cindent",     "cin",  "nocindent", "nocin",
+                \ "smartindent", "si",   "nosmartindent", "nosi",
+                \ "autoindent",  "ai",   "noautoindent", "noai",
+                \ "spell", "nospell",
+                \ "spelllang"
+                \ ]
 
-The g:secure_modelines_verbose option, if set to something true, will
+The g:secure_modelines_verbose variable, if set to something true, will
 make the script warn when a modeline attempts to set any other option.
 
-The g:secure_modelines_modelines option overrides the number of lines to
-check. By default it is 5.
+The g:secure_modelines_modelines variable overrides the number of lines
+to check. By default it is 5.
 
 If g:secure_modelines_leave_modeline is defined, the script will not
 clobber &modeline. Otherwise &modeline will be unset.

--- a/doc/securemodelines.txt
+++ b/doc/securemodelines.txt
@@ -30,22 +30,23 @@ The g:secure_modelines_allowed_items array contains allowed options.
 By default it is set as follows:
 
                                                      *securemodelines_options*
-    let g:secure_modelines_allowed_items = [
-                \ "textwidth",   "tw",
-                \ "softtabstop", "sts",
-                \ "tabstop",     "ts",
-                \ "shiftwidth",  "sw",
-                \ "expandtab",   "et",   "noexpandtab", "noet",
-                \ "filetype",    "ft",
-                \ "foldmethod",  "fdm",
-                \ "readonly",    "ro",   "noreadonly", "noro",
-                \ "rightleft",   "rl",   "norightleft", "norl",
-                \ "cindent",     "cin",  "nocindent", "nocin",
-                \ "smartindent", "si",   "nosmartindent", "nosi",
-                \ "autoindent",  "ai",   "noautoindent", "noai",
-                \ "spell", "nospell",
-                \ "spelllang"
-                \ ]
+let g:secure_modelines_allowed_items = [
+    \ "textwidth",       "tw",
+    \ "softtabstop",     "sts",
+    \ "tabstop",         "ts",
+    \ "shiftwidth",      "sw",
+    \ "expandtab",       "et",        "noexpandtab",    "noet",
+    \ "filetype",        "ft",
+    \ "foldmethod",      "fdm",
+    \ "formatoptions",   "fo",
+    \ "readonly",        "ro",        "noreadonly",     "noro",
+    \ "rightleft",       "rl",        "norightleft",    "norl",
+    \ "cindent",         "cin",       "nocindent",      "nocin",
+    \ "smartindent",     "si",        "nosmartindent",  "nosi",
+    \ "autoindent",      "ai",        "noautoindent",   "noai",
+    \ "spell",           "nospell",
+    \ "spelllang"
+    \ ]
 
 The g:secure_modelines_verbose variable, if set to something true, will
 make the script warn when a modeline attempts to set any other option.

--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -13,21 +13,22 @@ let g:loaded_securemodelines = 1
 
 if (! exists("g:secure_modelines_allowed_items"))
     let g:secure_modelines_allowed_items = [
-                \ "textwidth",       "tw",
-                \ "softtabstop",     "sts",
-                \ "tabstop",         "ts",
-                \ "shiftwidth",      "sw",
-                \ "expandtab",       "et",        "noexpandtab",    "noet",
-                \ "filetype",        "ft",
-                \ "foldmethod",      "fdm",
-                \ "readonly",        "ro",        "noreadonly",     "noro",
-                \ "rightleft",       "rl",        "norightleft",    "norl",
-                \ "cindent",         "cin",       "nocindent",      "nocin",
-                \ "smartindent",     "si",        "nosmartindent",  "nosi",
-                \ "autoindent",      "ai",        "noautoindent",   "noai",
-                \ "spell",           "nospell",
-                \ "spelllang"
-                \ ]
+        \ "textwidth",       "tw",
+        \ "softtabstop",     "sts",
+        \ "tabstop",         "ts",
+        \ "shiftwidth",      "sw",
+        \ "expandtab",       "et",        "noexpandtab",    "noet",
+        \ "filetype",        "ft",
+        \ "foldmethod",      "fdm",
+        \ "formatoptions",   "fo",
+        \ "readonly",        "ro",        "noreadonly",     "noro",
+        \ "rightleft",       "rl",        "norightleft",    "norl",
+        \ "cindent",         "cin",       "nocindent",      "nocin",
+        \ "smartindent",     "si",        "nosmartindent",  "nosi",
+        \ "autoindent",      "ai",        "noautoindent",   "noai",
+        \ "spell",           "nospell",
+        \ "spelllang"
+        \ ]
 endif
 
 if (! exists("g:secure_modelines_verbose"))

--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -13,19 +13,19 @@ let g:loaded_securemodelines = 1
 
 if (! exists("g:secure_modelines_allowed_items"))
     let g:secure_modelines_allowed_items = [
-                \ "textwidth",   "tw",
-                \ "softtabstop", "sts",
-                \ "tabstop",     "ts",
-                \ "shiftwidth",  "sw",
-                \ "expandtab",   "et",   "noexpandtab", "noet",
-                \ "filetype",    "ft",
-                \ "foldmethod",  "fdm",
-                \ "readonly",    "ro",   "noreadonly", "noro",
-                \ "rightleft",   "rl",   "norightleft", "norl",
-                \ "cindent",     "cin",  "nocindent", "nocin",
-                \ "smartindent", "si",   "nosmartindent", "nosi",
-                \ "autoindent",  "ai",   "noautoindent", "noai",
-                \ "spell", "nospell",
+                \ "textwidth",       "tw",
+                \ "softtabstop",     "sts",
+                \ "tabstop",         "ts",
+                \ "shiftwidth",      "sw",
+                \ "expandtab",       "et",        "noexpandtab",    "noet",
+                \ "filetype",        "ft",
+                \ "foldmethod",      "fdm",
+                \ "readonly",        "ro",        "noreadonly",     "noro",
+                \ "rightleft",       "rl",        "norightleft",    "norl",
+                \ "cindent",         "cin",       "nocindent",      "nocin",
+                \ "smartindent",     "si",        "nosmartindent",  "nosi",
+                \ "autoindent",      "ai",        "noautoindent",   "noai",
+                \ "spell",           "nospell",
                 \ "spelllang"
                 \ ]
 endif

--- a/plugin/securemodelines.vim
+++ b/plugin/securemodelines.vim
@@ -20,6 +20,7 @@ if (! exists("g:secure_modelines_allowed_items"))
         \ "expandtab",       "et",        "noexpandtab",    "noet",
         \ "filetype",        "ft",
         \ "foldmethod",      "fdm",
+        \ "foldmarker",      "fmr",
         \ "formatoptions",   "fo",
         \ "readonly",        "ro",        "noreadonly",     "noro",
         \ "rightleft",       "rl",        "norightleft",    "norl",
@@ -55,7 +56,7 @@ fun! <SID>IsInList(list, i) abort
 endfun
 
 fun! <SID>DoOne(item) abort
-    let l:matches = matchlist(a:item, '^\([a-z]\+\)\%([-+^]\?=[a-zA-Z0-9_\-,.]\+\)\?$')
+    let l:matches = matchlist(a:item, '^\([a-z]\+\)\%([-+^]\?=[a-zA-Z0-9_\-,.\[\]]\+\)\?$')
     if len(l:matches) > 0
         if <SID>IsInList(g:secure_modelines_allowed_items, l:matches[1])
             exec "setlocal " . a:item


### PR DESCRIPTION
The starting text for README.md and securemodelines.txt came from the vim.org page for this plugin. I rearranged and updated a few paragraphs. Then I added option 'formatoptions' for reasons explained in the commit comment.

I added support for foldmarker, but limited to marker `[[[,]]]]`. The reason is that the characters that consitute the foldmarker need to be added to the regex in DoOne. Since I use `[[[,]]]` I added `[` and `]` to the regex. Square brackets can be useful for other people too as an alternative to curly braces `{{{,}}}`

``` vim
    vim: fmr=[[[,]]]:
```

I would also like to add support for iskeyword, but haven't gotten around it. Motivating example for supporting iskeyword is `/usr/share/vim/vim74/doc/help.txt`

``` vim
    vim:tw=78:fo=tcq2:isk=!-~,^*,^\|,^\":ts=8:ft=help:norl:
```
